### PR TITLE
Enable grid support in autoprefixer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+3.1.0
+=====
+
+*   Enable grid support in autoprefixer
+
+
+
 3.0.3
 =====
 

--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -50,7 +50,9 @@ export class Compiler
         this.logger = logger;
         this.stylelintConfigFile = path.join(__dirname, "../.stylelintrc.yml");
         this.postProcessor = postcss([
-            require("autoprefixer")(),
+            require("autoprefixer")({
+                grid: "no-autoplace",
+            }),
             require("postcss-reporter")({
                 clearReportedMessages: true,
             }),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes<!-- don't forget to update CHANGELOG.md -->
| Improvement?  | no <!-- improves an existing feature, not adding a new one --> 
| BC breaks?    | no
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->
| Docs PR       | — <!-- insert URL here -->

<!-- describe your changes below -->
Enable the "safe" version of grid support in autoprefixer.

If you need `autoplace`, one can (and should) enable it via control comments in their project directly.