### PR TITLE
Support underscores in imported files from node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea
+/.stylelintcache
 /node_modules
 /package-lock.json
 
@@ -9,4 +10,3 @@
 
 # Allow test files
 !/tests/**/*.js
-/.stylelintcache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.3.3
+=====
+
+*   (improvement) Added support for loading `_` prefixed packages from node_modules.
+
+
 3.3.2
 =====
 

--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -258,19 +258,24 @@ export class Compiler
         if (url[0] === "~")
         {
             // map of file extensions and whether the file should be directly loaded or just as path returned
-            let extensions: {[extension: string]: boolean} = {
-                ".scss": false,
-                ".css": true,
-                "": false,
+            const fileNamePatterns: {[extension: string]: boolean} = {
+                "_%s.scss": false,
+                "_%s.css": true,
+                "%s.scss": false,
+                "%s.css": true,
+                "%s": false,
             };
 
-            for (let extension in extensions)
+            for (let pattern in fileNamePatterns)
             {
                 try {
-                    let loadFileContent = extensions[extension];
-                    let filePath = require.resolve(`${url.substr(1)}${extension}`);
+                    const shouldLoadFileContent = fileNamePatterns[pattern];
+                    const dir = path.dirname(url.substr(1));
+                    const filename = path.basename(url.substr(1));
 
-                    if (loadFileContent)
+                    const filePath = require.resolve(`${dir}/${pattern.replace('%s', filename)}`);
+
+                    if (shouldLoadFileContent)
                     {
                         return {
                             contents: fs.readFileSync(filePath, "utf-8"),


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | yes/no                                                                |
| New feature?  | yes/no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | yes/no <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | yes/no                                                                |
| Deprecations? | yes/no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | — <!-- insert URL here -->                                  |

<!-- describe your changes below -->
Now the import works the same way like a regular non-node_modules import