### PR TITLE
Properly resolve imports, even if directories are symlinked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+3.3.9
+=====
+
+*   (bug) Properly resolve imports, even if directories are symlinked.
+
+
 3.3.8
 =====
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "main": "src/index.js",
     "scripts": {
         "build": "node_modules/.bin/tsc --noEmitOnError --noErrorTruncation --listEmittedFiles --pretty --noUnusedLocals",
-        "dev": "node_modules/.bin/tsc --noEmitOnError --noErrorTruncation --listEmittedFiles --pretty",
+        "dev": "node_modules/.bin/tsc --noEmitOnError --noErrorTruncation --listEmittedFiles --pretty -w",
         "prepublishOnly": "npm run-script build",
         "test": "ava"
     },

--- a/src/Compiler.ts
+++ b/src/Compiler.ts
@@ -196,7 +196,7 @@ export class Compiler
                         ],
                         outputStyle: "expanded",
                         sourceComments: this.options.debug,
-                        importer: (url: string) => this.resolveImport(url),
+                        importer: (url: string, prev: string) => this.resolveImport(url, prev),
                     },
                     (error: Error|undefined, result: CompilationResult) =>
                     {
@@ -254,7 +254,7 @@ export class Compiler
     /**
      * Resolves sass imports
      */
-    private resolveImport (url: string): {file: string}|{contents: string}
+    private resolveImport (url: string, prev: string): {file: string}|{contents: string}
     {
         if (url[0] === "~")
         {
@@ -271,10 +271,18 @@ export class Compiler
             {
                 try {
                     const shouldLoadFileContent = fileNamePatterns[pattern];
-                    const dir = path.dirname(url.substr(1));
-                    const filename = path.basename(url.substr(1));
+                    const importPath = url.substr(1);
+                    const dir = path.dirname(importPath);
+                    const filename = path.basename(importPath);
 
-                    const filePath = require.resolve(`${dir}/${pattern.replace('%s', filename)}`);
+                    const filePath = require.resolve(
+                        `${dir}/${pattern.replace('%s', filename)}`, {
+                            paths: [
+                                path.dirname(prev),
+                                process.cwd(),
+                            ],
+                        },
+                    );
 
                     if (shouldLoadFileContent)
                     {


### PR DESCRIPTION
| Q             | A
| ------------- | --------------------------------------------------------------------- |
| BC breaks?    | no                                                                |
| New feature?  | no <!-- don't forget to update CHANGELOG.md -->                   |
| Improvement?  | no <!-- improves an existing feature, not adding a new one -->    |
| Bug fix?      | yes                                                               |
| Deprecations? | no <!-- don't forget to update UPGRADE.md and CHANGELOG.md -->    |
| Docs PR       | **missing** <!-- insert URL here -->                                  |

<!-- describe your changes below -->
This wasn't possible to implement in earlier versions, as the `prev` argument didn't exist back then.